### PR TITLE
feat: add responsive resume download button

### DIFF
--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -1,59 +1,12 @@
-import { AppBar, Toolbar, Container, Button, IconButton, Tooltip } from '@mui/material';
-import { PictureAsPdf } from '@mui/icons-material';
+import { AppBar, Toolbar, Container } from '@mui/material';
 import { Logo } from '@atoms/Logo';
 
 export const Header = () => {
-  const handleResumeDownload = () => {
-    const link = document.createElement('a');
-    link.href = '/assets/Marasco_Resume2025.pdf';
-    link.download = 'Christopher_Marasco_Resume.pdf';
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-  };
-
   return (
     <AppBar position="static" color="transparent" elevation={0}>
       <Container maxWidth="lg">
         <Toolbar sx={{ justifyContent: 'space-between', py: 2 }}>
           <Logo variant="h5" />
-          
-          {/* Desktop Resume Button */}
-          <Button
-            variant="outlined"
-            startIcon={<PictureAsPdf />}
-            onClick={handleResumeDownload}
-            sx={{
-              display: { xs: 'none', sm: 'flex' },
-              borderColor: 'primary.main',
-              color: 'primary.main',
-              '&:hover': {
-                borderColor: 'primary.dark',
-                backgroundColor: 'primary.main',
-                color: 'white',
-              },
-            }}
-          >
-            Resume
-          </Button>
-
-          {/* Mobile Resume Button */}
-          <Tooltip title="Resume" placement="left">
-            <IconButton
-              onClick={handleResumeDownload}
-              sx={{
-                display: { xs: 'flex', sm: 'none' },
-                color: 'primary.main',
-                '&:hover': {
-                  backgroundColor: 'primary.main',
-                  color: 'white',
-                },
-              }}
-              aria-label="Resume"
-            >
-              <PictureAsPdf />
-            </IconButton>
-          </Tooltip>
         </Toolbar>
       </Container>
     </AppBar>

--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -1,5 +1,5 @@
 import { AppBar, Toolbar, Container, Button, IconButton, Tooltip } from '@mui/material';
-import { Download, GetApp } from '@mui/icons-material';
+import { PictureAsPdf } from '@mui/icons-material';
 import { Logo } from '@atoms/Logo';
 
 export const Header = () => {
@@ -21,7 +21,7 @@ export const Header = () => {
           {/* Desktop Resume Button */}
           <Button
             variant="outlined"
-            startIcon={<Download />}
+            startIcon={<PictureAsPdf />}
             onClick={handleResumeDownload}
             sx={{
               display: { xs: 'none', sm: 'flex' },
@@ -34,11 +34,11 @@ export const Header = () => {
               },
             }}
           >
-            Download Resume
+            Resume
           </Button>
 
           {/* Mobile Resume Button */}
-          <Tooltip title="Download Resume" placement="left">
+          <Tooltip title="Resume" placement="left">
             <IconButton
               onClick={handleResumeDownload}
               sx={{
@@ -49,9 +49,9 @@ export const Header = () => {
                   color: 'white',
                 },
               }}
-              aria-label="Download Resume"
+              aria-label="Resume"
             >
-              <GetApp />
+              <PictureAsPdf />
             </IconButton>
           </Tooltip>
         </Toolbar>

--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -1,12 +1,59 @@
-import { AppBar, Toolbar, Container } from '@mui/material';
+import { AppBar, Toolbar, Container, Button, IconButton, Tooltip } from '@mui/material';
+import { Download, GetApp } from '@mui/icons-material';
 import { Logo } from '@atoms/Logo';
 
 export const Header = () => {
+  const handleResumeDownload = () => {
+    const link = document.createElement('a');
+    link.href = '/assets/Marasco_Resume2025.pdf';
+    link.download = 'Christopher_Marasco_Resume.pdf';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
   return (
     <AppBar position="static" color="transparent" elevation={0}>
       <Container maxWidth="lg">
         <Toolbar sx={{ justifyContent: 'space-between', py: 2 }}>
           <Logo variant="h5" />
+          
+          {/* Desktop Resume Button */}
+          <Button
+            variant="outlined"
+            startIcon={<Download />}
+            onClick={handleResumeDownload}
+            sx={{
+              display: { xs: 'none', sm: 'flex' },
+              borderColor: 'primary.main',
+              color: 'primary.main',
+              '&:hover': {
+                borderColor: 'primary.dark',
+                backgroundColor: 'primary.main',
+                color: 'white',
+              },
+            }}
+          >
+            Download Resume
+          </Button>
+
+          {/* Mobile Resume Button */}
+          <Tooltip title="Download Resume" placement="left">
+            <IconButton
+              onClick={handleResumeDownload}
+              sx={{
+                display: { xs: 'flex', sm: 'none' },
+                color: 'primary.main',
+                '&:hover': {
+                  backgroundColor: 'primary.main',
+                  color: 'white',
+                },
+              }}
+              aria-label="Download Resume"
+            >
+              <GetApp />
+            </IconButton>
+          </Tooltip>
         </Toolbar>
       </Container>
     </AppBar>

--- a/src/components/organisms/Resume/components/Sidebar.tsx
+++ b/src/components/organisms/Resume/components/Sidebar.tsx
@@ -6,6 +6,7 @@ const contactInfo = [
   { icon: 'phone', text: '585-857-0319', type: 'phone' },
   { icon: 'map-pin', text: 'Rochester, NY 14604', type: 'location' },
   { icon: 'github', text: 'github.com/cxm6467', type: 'github', url: 'https://github.com/cxm6467' },
+  { icon: 'resume', text: 'Resume', type: 'resume', isDownload: true },
 ];
 
 const skills = [
@@ -28,6 +29,15 @@ const certifications = [
 
 export const Sidebar = () => {
   const theme = useTheme();
+
+  const handleResumeDownload = () => {
+    const link = document.createElement('a');
+    link.href = '/assets/Marasco_Resume2025.pdf';
+    link.download = 'Christopher_Marasco_Resume.pdf';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
 
   const iconProps = {
     width: 16,
@@ -60,6 +70,12 @@ export const Sidebar = () => {
     </Box>
   );
 
+  const ResumeIcon = () => (
+    <Box component="svg" sx={iconProps} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z" />
+    </Box>
+  );
+
   const getIcon = (iconType: string) => {
     switch (iconType) {
       case 'envelope':
@@ -70,6 +86,8 @@ export const Sidebar = () => {
         return <MapPinIcon />;
       case 'github':
         return <GitHubIcon />;
+      case 'resume':
+        return <ResumeIcon />;
       default:
         return null;
     }
@@ -246,7 +264,26 @@ export const Sidebar = () => {
               >
                 {getIcon(contact.icon)}
               </Box>
-              {contact.url ? (
+              {contact.isDownload ? (
+                <Box
+                  component="button"
+                  onClick={handleResumeDownload}
+                  sx={{
+                    color: 'inherit',
+                    textDecoration: 'none',
+                    background: 'none',
+                    border: 'none',
+                    cursor: 'pointer',
+                    fontSize: 'inherit',
+                    padding: 0,
+                    '&:hover': {
+                      textDecoration: 'underline',
+                    },
+                  }}
+                >
+                  {contact.text}
+                </Box>
+              ) : contact.url ? (
                 <Link
                   href={contact.url}
                   target="_blank"


### PR DESCRIPTION
## Summary
- Added responsive resume download button to header
- Desktop: full button with "Resume" text and PDF icon
- Mobile: compact icon-only button with tooltip
- Downloads resume PDF with user-friendly filename

## Changes
- Updated Header component with resume download functionality
- Added proper PDF icon (PictureAsPdf) from Material-UI
- Implemented responsive design for mobile and desktop
- Clean button styling with hover effects

## Test plan
- [ ] Verify button appears correctly on desktop (sm+ breakpoints)
- [ ] Verify icon-only button appears on mobile (xs breakpoint)
- [ ] Test resume download functionality
- [ ] Check button hover states and accessibility